### PR TITLE
[feature] 개인정보 입력 페이지 구현

### DIFF
--- a/src/main/java/com/toiletissue/auth/controller/MainController.java
+++ b/src/main/java/com/toiletissue/auth/controller/MainController.java
@@ -13,12 +13,12 @@ public class MainController {
     public void main() {
     }
 
-    @Value("${api.kakao.key}")
-    private String kakaoKey;
-
-    @GetMapping("/main")
-    public String mainPage(Model model) {
-        model.addAttribute("kakaoKey", kakaoKey);
-        return "main";
-    }
+//    @Value("${api.kakao.key}")
+//    private String kakaoKey;
+//
+//    @GetMapping("/main")
+//    public String mainPage(Model model) {
+//        model.addAttribute("kakaoKey", kakaoKey);
+//        return "main";
+//    }
 }

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -80,7 +80,7 @@
 </div>
 
 
-<script th:src="@{|//dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoKey}|}"></script>
+<!--<script th:src="@{|//dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoKey}|}"></script>-->
 <script>
     var container = document.getElementById('map');
     var options = {

--- a/src/main/resources/templates/member/register.html
+++ b/src/main/resources/templates/member/register.html
@@ -3,50 +3,184 @@
 <head>
     <meta charset="UTF-8">
     <title>회원가입</title>
-
     <style>
+        *{box-sizing:border-box; font-family: 'Arial', sans-serif;}
 
+        .content {
+            padding: 30px 25px;
+        }
 
+        .title {
+            margin: 10px 0 20px;
+            font-size: 22px;
+            font-weight: 700;
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+        }
+
+        label {
+            font-size: 14px;
+            font-weight: 600;
+            color: #2f1a48;
+        }
+
+        .field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .input, select {
+            padding: 10px 12px;
+            border: 1px solid rgba(0,0,0,.25);  /* ✅ 피그마 값 */
+            border-radius: 8px;
+            font-size: 14px;
+            outline: none;
+        }
+
+        .input:focus, select:focus {
+            border-color: rgba(0,0,0,.5);
+            box-shadow: 0 0 0 3px rgba(138, 78, 191, 0.2);
+        }
+
+        .input-row {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .input-row .input {
+            flex: 1;
+        }
+
+        .check-btn {
+            height: 36px;
+            padding: 0 14px;
+            border: 1px solid rgba(0,0,0,.25);
+            border-radius: 8px;
+            background: #fff;
+            cursor: pointer;
+            font-size: 13px;
+        }
+
+        .hint {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .actions {
+            margin-top: 10px;
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        #nextBtn {
+            height: 30px;
+            padding: 0 16px;
+            border: 1px solid rgba(0,0,0,.25);
+            border-radius: 8px;
+            background: #ffffff;
+            color: #000000;
+            font-weight: 600;
+            font-size: 13px;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
 
 <div th:include="/common/header.html"></div>
 <div id="main">
-<h2>회원가입</h2>
+    <div class="content">
+        <p class="title">회원가입</p>
 
-<form th:action="@{/member/register}" method="post" th:object="${member}">
-    <!-- CSRF 시큐리티 사용 시 주석 해제 -->
-    <!-- <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/> -->
+        <form th:action="@{/member/register}" method="post" th:object="${member}">
+            <div class="field">
+                <label for="memberId">아이디</label>
+                <div class="input-row">
+                    <input class="input" type="text" th:field="*{memberId}" id="memberId" />
+                    <button class="check-btn" type="button" id="checkIdBtn">중복확인</button>
+                </div>
+                <span id="idMsg" class="hint"></span>
+            </div>
 
-    <label>아이디: </label>
-    <input type="text" th:field="*{memberId}" id="memberId"/>
-    <button type="button">아이디 중복확인</button>
-    <span id="idMsg"></span><br>
+            <div class="field">
+                <label for="memberPwd">비밀번호</label>
+                <input class="input" type="password" th:field="*{memberPwd}" id="memberPwd" />
+                <p class="hint">* 영문, 숫자 포함 8자 이상</p>
+            </div>
 
-    <label>비밀번호: </label>
-    <input type="password" th:field="*{memberPwd}"/><br>
-    <p > * 비밀번호는 영문, 숫자 포함 8자 이상* </p>
-    <label>비밀번호 확인 : </label>
-    <input type="password"><br>
+            <div class="field">
+                <label for="pwdConfirm">비밀번호 확인</label>
+                <input class="input" type="password" id="pwdConfirm" />
+            </div>
 
-    <label>이름: </label>
-    <input type="text" th:field="*{memberName}"/><br>
+            <div class="field">
+                <label for="email">이메일</label>
+                <input class="input" type="email" th:field="*{email}" id="email" />
+            </div>
 
-    <label>이메일: </label>
-    <input type="email" th:field="*{email}"/><br>
+            <div class="field">
+                <label for="memberName">이름</label>
+                <input class="input" type="text" th:field="*{memberName}" id="memberName" />
+            </div>
 
-    <label>생년월일: </label>
-    <input type="date" th:field="*{memberBdate}"/><br>
+            <div class="field">
+                <label for="memberBdate">생년월일</label>
+                <input class="input" type="date" th:field="*{memberBdate}" id="memberBdate" />
+            </div>
 
-    <label>성별: </label>
-    <select th:field="*{memberGender}">
-        <option value="M">남자</option>
-        <option value="F">여자</option>
-    </select><br>
+            <div class="field">
+                <label for="memberGender">성별</label>
+                <select class="input" th:field="*{memberGender}" id="memberGender">
+                    <option value="M">남자</option>
+                    <option value="F">여자</option>
+                </select>
+            </div>
 
-    <button type="submit">회원가입</button>
-</form>
+            <div class="actions">
+                <button id="nextBtn" type="submit">다음</button>
+            </div>
+        </form>
+    </div>
 </div>
+
+<script>
+    // 아이디 중복확인 (GET /member/register/check-id?memberId=xxx 로 가정)
+    document.getElementById('checkIdBtn').addEventListener('click', async () => {
+        const memberId = document.getElementById('memberId').value.trim();
+        const msg = document.getElementById('idMsg');
+
+        if (!memberId) { msg.textContent = '아이디를 입력하세요.'; msg.style.color='#a30000'; return; }
+
+        try {
+            const res = await fetch(`/member/register/check-id?memberId=${encodeURIComponent(memberId)}`);
+            const data = await res.json(); // {available:true/false}
+
+            msg.textContent = data.available ? '사용 가능한 아이디입니다.' : '이미 사용 중인 아이디입니다.';
+            msg.style.color = data.available ? '#2a7a2a' : '#a30000';
+        } catch {
+            msg.textContent = '중복확인 API가 아직 연결되지 않았습니다.'; msg.style.color='#a30000';
+        }
+    });
+
+    // 비밀번호 일치 확인
+    document.getElementById('registerForm').addEventListener('submit', (e) => {
+        const p1 = document.getElementById('memberPwd').value;
+        const p2 = document.getElementById('pwdConfirm').value;
+        const hint = document.getElementById('pwdMsg');
+
+        if (p1 !== p2) {
+            e.preventDefault();
+            hint.textContent = '비밀번호가 일치하지 않습니다.';
+            hint.style.color = '#a30000';
+            document.getElementById('pwdConfirm').focus();
+        }
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#56 

## 📃 작업 상세 내용 
사용자 회원가입 페이지 중 개인정보 입력 페이지를 구현해 아이디 중복확인과 비밀번호 일치 확인을 할 수 있다.

## 📸 결과 
<img width="463" height="625" alt="스크린샷 2025-09-17 오전 9 43 40" src="https://github.com/user-attachments/assets/5be5dcb7-4861-42fa-8afb-e84424187eec" />

