### PR TITLE
[feature] 관리자 페이지 신고 리뷰, 선택 리뷰 관리 페이지 구현

### DIFF
--- a/src/main/java/com/toiletissue/request/controller/RequestController.java
+++ b/src/main/java/com/toiletissue/request/controller/RequestController.java
@@ -40,9 +40,6 @@ public class RequestController {
         } else if(page > totalPages){
             page = totalPages;
         }
-
-
-
         int start = (page-1)*pageSize; //페이지 시작 문의 번호
         int end = Math.min(start+pageSize,totalRequests); // 페이지 끝 문의 번호
 

--- a/src/main/java/com/toiletissue/review/controller/ReviewController.java
+++ b/src/main/java/com/toiletissue/review/controller/ReviewController.java
@@ -1,14 +1,16 @@
 package com.toiletissue.review.controller;
 
+import com.toiletissue.request.model.dto.RequestDTO;
 import com.toiletissue.review.model.dto.ReviewDTO;
 import com.toiletissue.review.model.service.ReviewService;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -20,15 +22,128 @@ public class ReviewController {
 
     @GetMapping("/declared")
     public String reviewDeclared(
-            Model model){
-        List<ReviewDTO> reviewList = reviewService.selectAllReview();
+            Model model,
+            @RequestParam(value = "page", defaultValue = "1") int page)
+            {
 
-        model.addAttribute("reviewList",reviewList);
+
+        List<ReviewDTO> reviewList = reviewService.selectDeclaredReview();
+
+
+        int totalRequests = reviewList.size(); // 총 문의 수
+        int pageSize = 10; // 한 페이지당 문의 수
+        int totalPages = (int)(Math.ceil((double)totalRequests/pageSize)); // 총 페이지 수
+
+        if(page <= 0){
+            page = 1;
+        } else if(page > totalPages){
+            page = totalPages;
+        }
+        int start = (page-1)*pageSize; //페이지 시작 문의 번호
+        int end = Math.min(start+pageSize,totalRequests); // 페이지 끝 문의 번호
+
+        List<ReviewDTO> pagedReviews = new ArrayList<>();
+        if(!reviewList.isEmpty()){
+            pagedReviews = reviewList.subList(start,end);
+        }
+
+        System.out.println("page = " + page);
+        System.out.println("totalPages = " + totalPages);
+        System.out.println("end = " + end);
+        System.out.println("start = " + start);
+        for(ReviewDTO rev : pagedReviews){
+            System.out.println("페이지에 보여주세요 declared review"+rev);
+        }
+        int buttonCount = 10; // 한 번에 보여질 페이지 버튼 수
+        int startPage = ((page - 1) / buttonCount) * buttonCount + 1;
+        int endPage = Math.min(startPage + buttonCount - 1, totalPages);
+
+        model.addAttribute("startPage", startPage);
+        model.addAttribute("endPage", endPage);
+
+
+
+
+        model.addAttribute("reviewList",pagedReviews);
+//        model.addAttribute("value",value);
+        model.addAttribute("page",page);
+        model.addAttribute("totalPages",totalPages);
 
         return "/review/declared";
     }
 
     @GetMapping("/search")
-    public void reviewSearch(){}
+    public String reviewSearch(
+            Model model,
+            @RequestParam(value = "page2", defaultValue = "1") int page,
+            @RequestParam(value="criteria", defaultValue = "r.review_no") String criteria,
+            @RequestParam(value="search",defaultValue = "%%") String search)
+    {
+
+
+        List<ReviewDTO> reviewList2 = reviewService.selectAllReview(criteria,search);
+
+
+        int totalRequests = reviewList2.size(); // 총 문의 수
+        int pageSize = 10; // 한 페이지당 문의 수
+        int totalPages = (int)(Math.ceil((double)totalRequests/pageSize)); // 총 페이지 수
+
+        if(page <= 0){
+            page = 1;
+        } else if(page > totalPages){
+            page = totalPages;
+        }
+        int start = (page-1)*pageSize; //페이지 시작 문의 번호
+        int end = Math.min(start+pageSize,totalRequests); // 페이지 끝 문의 번호
+
+        List<ReviewDTO> pagedReviews2 = new ArrayList<>();
+        if(!reviewList2.isEmpty()){
+            pagedReviews2 = reviewList2.subList(start,end);
+        }
+        for(ReviewDTO rev : pagedReviews2){
+            System.out.println("1페이지에 보여주세요 all review"+rev);
+        }
+        System.out.println("page = " + page);
+        System.out.println("totalPages = " + totalPages);
+        System.out.println("end = " + end);
+        System.out.println("start = " + start);
+        for(ReviewDTO rev : pagedReviews2){
+            System.out.println("페이지에 보여주세요 all review"+rev);
+        }
+        int buttonCount = 10; // 한 번에 보여질 페이지 버튼 수
+        int startPage = ((page - 1) / buttonCount) * buttonCount + 1;
+        int endPage = Math.min(startPage + buttonCount - 1, totalPages);
+
+        model.addAttribute("startPage2", startPage);
+        model.addAttribute("endPage2", endPage);
+
+
+
+
+        model.addAttribute("reviewList2",pagedReviews2);
+//        model.addAttribute("value",value);
+        model.addAttribute("page2",page);
+        model.addAttribute("totalPages2",totalPages);
+        model.addAttribute("criteria",criteria);
+        model.addAttribute("search",search);
+
+        return "/review/search";
+    }
+
+    @PostMapping("/declared/cancel")
+    public ModelAndView cancelDeclaration(ModelAndView mv, @ModelAttribute ReviewDTO reviewDTO){
+
+        reviewService.cancelDeclaration(reviewDTO);
+
+        mv.setViewName("redirect:/review/declared");
+
+
+        return mv;
+    }
+
+
+
+//    @GetMapping("/search")
+//    public void reviewSearch(){}
 
 }

--- a/src/main/java/com/toiletissue/review/model/dao/ReviewMapper.java
+++ b/src/main/java/com/toiletissue/review/model/dao/ReviewMapper.java
@@ -6,5 +6,9 @@ import org.apache.ibatis.annotations.Mapper;
 import java.util.List;
 @Mapper
 public interface ReviewMapper {
-    List<ReviewDTO> selectAllReview();
+    List<ReviewDTO> selectDeclaredReview();
+
+    void cancelDeclaration(ReviewDTO reviewDTO);
+
+    List<ReviewDTO> selectAllReview(String criteria, String search);
 }

--- a/src/main/java/com/toiletissue/review/model/dto/ReviewDTO.java
+++ b/src/main/java/com/toiletissue/review/model/dto/ReviewDTO.java
@@ -9,10 +9,11 @@ public class ReviewDTO {
     private String stationName;
     private String toiletLocation;
     private String date;
+    private int decNum;
 
     public ReviewDTO(){}
 
-    public ReviewDTO(String content, int score, int no, String memberId, String stationName, String toiletLocation, String date) {
+    public ReviewDTO(String content, int score, int no, String memberId, String stationName, String toiletLocation, String date, int decNum) {
         this.content = content;
         this.score = score;
         this.no = no;
@@ -20,6 +21,7 @@ public class ReviewDTO {
         this.stationName = stationName;
         this.toiletLocation = toiletLocation;
         this.date = date;
+        this.decNum = decNum;
     }
 
     public String getContent() {
@@ -78,6 +80,14 @@ public class ReviewDTO {
         this.date = date;
     }
 
+    public int getDecNum() {
+        return decNum;
+    }
+
+    public void setDecNum(int decNum) {
+        this.decNum = decNum;
+    }
+
     @Override
     public String toString() {
         return "ReviewDTO{" +
@@ -88,6 +98,7 @@ public class ReviewDTO {
                 ", stationName='" + stationName + '\'' +
                 ", toiletLocation='" + toiletLocation + '\'' +
                 ", date='" + date + '\'' +
+                ", decNum=" + decNum +
                 '}';
     }
 }

--- a/src/main/java/com/toiletissue/review/model/service/ReviewService.java
+++ b/src/main/java/com/toiletissue/review/model/service/ReviewService.java
@@ -12,7 +12,15 @@ public class ReviewService {
     @Autowired
     private ReviewMapper reviewMapper;
 
-    public List<ReviewDTO> selectAllReview() {
-        return reviewMapper.selectAllReview();
+    public List<ReviewDTO> selectDeclaredReview() {
+        return reviewMapper.selectDeclaredReview();
+    }
+
+    public void cancelDeclaration(ReviewDTO reviewDTO) {
+        reviewMapper.cancelDeclaration(reviewDTO);
+    }
+
+    public List<ReviewDTO> selectAllReview(String criteria, String search) {
+        return reviewMapper.selectAllReview(criteria,search);
     }
 }

--- a/src/main/resources/mappers/ReviewMapper.xml
+++ b/src/main/resources/mappers/ReviewMapper.xml
@@ -11,23 +11,46 @@
         <result property="stationName" column="station_name"/>
         <result property="toiletLocation" column="toilet_location"/>
         <result property="date" column="review_date"/>
+        <result property="decNum" column="dec_num"/>
+    </resultMap>
+
+    <resultMap id="declaration" type="com.toiletissue.declaration.model.dto.DeclarationDTO">
 
     </resultMap>
 
+    <select id="selectDeclaredReview" resultMap="review">
+        select
+        r.review_no,
+        r.review_content,
+        r.review_score,
+        r.member_id,
+        r.station_name,
+        r.toilet_location,
+        r.review_date,
+        count(r.review_no) as `dec_num`
+        from review r
+        join declaration c on r.review_no = c.review_no
+        group by review_no
+        having dec_num>=2;
+    </select>
+
     <select id="selectAllReview" resultMap="review">
         select
-               review_no,
-               review_content,
-               review_score,
-               member_id,
-               station_name,
-               toilet_location,
-               review_date
-          from review
-        where review_no in (select
-        review_no
-        from declaration
-        group by review_no
-        having count(*) >2);
+        r.review_no,
+        r.review_content,
+        r.review_score,
+        r.member_id,
+        r.station_name,
+        r.toilet_location,
+        r.review_date,
+        count(d.review_no) as `dec_num`
+        from review r
+        left join declaration d on r.review_no = d.review_no
+        where ${criteria} like '${search}'
+        group by r.review_no;
     </select>
+
+    <delete id="cancelDeclaration">
+        delete from declaration where review_no = #{no}
+    </delete>
 </mapper>

--- a/src/main/resources/templates/notice/manager.html
+++ b/src/main/resources/templates/notice/manager.html
@@ -66,10 +66,12 @@
         /*리스트 레이아웃(한 개당)*/
         .notice{
             height: 50%;
+            background-color: white;
+            margin-bottom: 3%;
 
         }
         .title,.content {
-            background: white;
+            /*background: white;*/
             z-index: 1000;
         }
         /*상세 정보 버튼*/
@@ -399,6 +401,8 @@
 
 </div>
 <script>
+    const $notices = document.querySelectorAll('.notice')
+
     const $detailbtn = document.querySelectorAll('.detailbtn');
     const $detail = document.querySelector('.details');
     const $dtitle = document.getElementById('dtitle');
@@ -516,11 +520,17 @@
     $detailbtn.forEach((btn,i)=>{
         btn.addEventListener('click',function (){
 
+            $notices.forEach((a)=>{
+                a.style.background='#ffffff'
+            })
+
+
             // 수정 창 끄기
             $update.classList.replace('viewupdate','update')
             // 추가 입력 정보 삭제
             $ititle.value='';
             $icontent.value='';
+
 
 
             const $notice = btn.closest('.notice');/*closest() : 가장 가까운 태그로 초기화*/
@@ -529,15 +539,21 @@
             const date = $notice.querySelector('.date')?.textContent||'';
             const no = $notice.querySelector('.no')?.textContent||'';
 
+            $notice.style.background='#fafad2'
+
             // 버튼에 해당하는 공지사항 제목,내용 모달창에 띄우기 (비동기)
             $dtitle.textContent=title;
             $dcontent.textContent=content;
             $ddate.textContent=date;
             $dno.textContent=no;
 
+            // $noticeContent.style.background="#fafad2"
+            // $noticeTitle.style.background="#fafad2"
+
             // 인덱스에 해당하는 내용을 가진 모달창이 열려있을 때 상세버튼을 누르면 꺼지게
             if($detail.classList.contains('viewdetails') && openedIndex === i){
                 $detail.classList.replace('viewdetails','details')
+                $notice.style.background='#ffffff'
                 openedIndex = null;
                 return;
             }

--- a/src/main/resources/templates/request/manager.html
+++ b/src/main/resources/templates/request/manager.html
@@ -75,7 +75,7 @@
             border-radius: 8px;
         }
         .title,.status {
-            background: white;
+            /*background: white;*/
             z-index: 1000;
         }
         /*상세 정보 버튼*/
@@ -489,6 +489,8 @@
 
     </div>
 <script>
+    const $notices = document.querySelectorAll('.notice')
+
     const $detailbtn = document.querySelectorAll('.detailbtn');
     const $detail = document.querySelector('.details');
     const $dtitle = document.getElementById('dtitle');
@@ -615,6 +617,10 @@
     $detailbtn.forEach((btn,i)=>{
         btn.addEventListener('click',function (){
 
+            $notices.forEach((a)=>{
+                a.style.background='#ffffff'
+            })
+
             // 수정 창 끄기
             $update.classList.replace('viewupdate','update')
             // 추가 입력 정보 삭제
@@ -630,6 +636,8 @@
             const no = $notice.querySelector('.no')?.textContent||'';
             const answer = $notice.querySelector('.answer')?.textContent||'';
             const reject = $notice.querySelector('.reject')?.textContent||'';
+
+            $notice.style.background="#fafad2"
 
 
             // 버튼에 해당하는 공지사항 제목,내용 모달창에 띄우기 (비동기)
@@ -651,6 +659,7 @@
             // 인덱스에 해당하는 내용을 가진 모달창이 열려있을 때 상세버튼을 누르면 꺼지게
             if($detail.classList.contains('viewdetails') && openedIndex === i){
                 $detail.classList.replace('viewdetails','details')
+                $notice.style.background='#ffffff'
                 openedIndex = null;
                 return;
             }

--- a/src/main/resources/templates/review/declared.html
+++ b/src/main/resources/templates/review/declared.html
@@ -53,6 +53,219 @@
             scrollbar-width: none;
             overflow-x: hidden;
         }
+        .stationName{
+            width: 50%;
+            position: relative;
+            top: 20%;
+            font-size: 20px;
+            background-color: #FAFAC2;
+        }
+        .toiletLocation{
+            position: relative;
+            right: %;
+            top:20%;
+            font-size: 20px;
+        }
+        .detailbtn{
+            position: relative;
+            left: 95%;
+            font-size: 20px;
+        }
+        .date{
+            position: relative;
+            bottom: 20%;
+            right: 50%;
+            font-size: 10px;
+            font-family: AggravoL;
+            /*background-color: #2f1a48;*/
+            width: 12%;
+        }
+        .memberId{
+            position: relative;
+            right: 49%;
+            bottom: 20%;
+            font-size: 10px;
+            font-family: AggravoL;
+        }
+        .toiletName{
+            /*background-color: #FAFAC2;*/
+            width: 50%;
+            font-size: 20px;
+            position: relative;
+            top: 20%;
+        }
+        .details{
+            width: 30%;
+            height: 60%;
+            position: fixed;
+            left: 51%;
+            top: 22%;
+            background: white;
+            /*border: black 10px solid; !*레이아웃 확인용*!*/
+            display: none;
+            /*justify-content: center;*!*/
+            flex-direction: column;
+            align-items: center;
+            border-radius: 8px;
+        }
+        .view-details{
+            width: 30%;
+            height: 60%;
+            position: fixed;
+            left: 51%;
+            top: 22%;
+            background: white;
+            /*border: black 10px solid; !*레이아웃 확인용*!*/
+            display: flex;
+            /*justify-content: center;*!*/
+            flex-direction: column;
+            align-items: center;
+            border-radius: 8px;
+        }
+        .details-layout{
+            padding: 5%;
+            font-family: AggravoM;
+            width: 90%;
+            height: 90%;
+            /*border: black 5px solid;*/
+        }
+        #toiletName{
+            /*background-color: cyan;*/
+        }
+        #content{
+            background-color: #d9d9d9;
+            width: 100%;
+            height: 45%;
+        }
+        #date-layout{
+            /*background-color: #d9d9d9;*/
+        }
+        #memberId-layout{
+            /*background-color: #FAFAC2;*/
+            width: 50%;
+            height: 15%;
+            position: relative;
+
+
+        }
+
+        #decNum-layout{
+            /*background-color: greenyellow;*/
+            width: 50%;
+            height: 15%;
+            position: relative;
+            bottom: 15%;
+            left: 50%;
+
+        }
+
+        .penalty,.dec-cancel{
+            font-family: AggravoM;
+            font-size: 20px;
+            width: 100px;
+            height: 30px;
+            background: white;
+            border: #d9d9d9 solid 4px;
+            border-radius: 8px;
+            text-align: center;
+            align-content: center;
+        }
+        .btns{
+            position: fixed;
+            left: 68%;
+            top: 75%;
+            width: 100%;
+            height: 200%;
+            display: flex;
+            gap: 0.5%;
+        }
+        /*신고 취소 확인 모달 배경*/
+        .cancel-back{
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,50%);
+            z-index: 1100;
+            display: none;
+        }
+        /*신고 취소 확인 모달 창*/
+        #dec-cancel-modal{
+            width: 25%;
+            height: 30%;
+            background: white;
+            position: fixed;
+            top: 35%;
+            left: 37.5%;
+            z-index: 1004;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        /*신고 취소 완료 모달창*/
+        .cancelsuccess{
+            width: 25%;
+            height: 30%;
+            background: white;
+            position: fixed;
+            top: 35%;
+            left: 37.5%;
+            z-index: 1005;
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        .cancelbtns{
+            width: 30%;
+            height: 10%;
+            display: flex;
+            gap: 5%;
+            position: relative;
+            /*border: black solid 1px;*/
+            justify-content: space-between;
+            top: 70%;
+        }
+        #canN,#canY{
+            border: none;
+            width: 50px;
+            height: 30px;
+        }
+        .pagination{
+            width: 15%;
+            position: fixed;
+            top: 90%;
+            left: 45%;
+            /*border: black solid 1px;*/
+            display: flex;
+            justify-content: center;
+            gap: 10%;
+        }
+        .pagination a{
+            text-decoration: none;
+            color: black;
+            font-size: 30px;
+        }
+        .pagination a.active{
+            color: #d9d9d9;
+        }
+        @keyframes selected {
+            from{
+                transform: rotate(0deg);
+            }
+            to{
+                transform: rotate(90deg)
+            }
+        }
+        .selected{
+            /*animation: selected 0.1s linear;*/
+            transform: rotate(90deg);
+        }
+        {
+            background-color: #FAFAC2;
+            font-family: AggravoL;
+            font-size: 15px;
+            position: relative;
+            bottom: 30%;
+        }
     </style>
 </head>
 <body>
@@ -60,19 +273,193 @@
 <div th:include="/manager/sidebar-rev.html"></div>
 <div id="mainmenu">
     <div id="pagetitle">신고 리뷰 관리</div>
+<!--    <form action="/review/declared/search" method="post">-->
+<!--        <select name="" id="criteria">-->
+<!--            <option value="" selected>검색 기준</option>-->
+<!--            <option value="station_name" id="sn">역명</option>-->
+<!--            <option value="member_id" id="mi">사용자ID</option>-->
+<!--        </select>-->
+<!--        <input type="text" id="inputbox" name="search" placeholder="검색기준을 입력해주세요">-->
+<!--        <button type="submit">검색</button>-->
+<!--    </form>-->
     <div id="reviewlist">
         <div class="review" th:each="review : ${reviewList}">
             <div class="detailbtn">▶</div> <!--detailbtn은 여러개있을 수 있고 그에 따른 인덱스 있음-->
-            <div class="content" th:text="${review.stationName}"></div><!--상세페이지 내용 확인-->
+            <div class="toiletName" th:text="${review.stationName} +' ' +${review.toiletLocation}"></div>
+            <div class="stationName" th:text="${review.stationName}" hidden></div><!--역명확인용-->
+            <div class="toiletLocation" th:text="${review.toiletLocation}" hidden></div><!--화장실위치확인용-->
             <div class="date" th:text="${review.date}"></div><!--날짜 확인용-->
-            <div class="memberId" th:text="${review.memberId}"></div><!--날짜 확인용-->
-<!--            <div class="no" th:text="${request.no}" style="display: none"></div> &lt;!&ndash;번호 확인용...&ndash;&gt;-->
-<!--            <div class="id" th:text="${request.id}" style="display: none"></div> &lt;!&ndash;id 확인용...&ndash;&gt;-->
-<!--            <div class="answer" th:text="${request.answer}" style="display: none"></div>-->
-<!--            <div class="reject" th:text="${request.reject}" style="display: none"></div>-->
+            <div class="memberId" th:text="'ID : '+${review.memberId}"></div><!--리뷰작성자id 확인용-->
+            <div class="no" th:text="${review.no}" style="display: none"></div> <!--번호 확인용...-->
+            <div class="content" th:text="${review.content}" style="display: none"></div> <!--리뷰내용 확인용...-->
+            <div class="decNum" th:text="${review.decNum}" style="display: none"></div> <!--신고횟수 확인용...-->
+
             <div class="empty"></div>
         </div>
     </div>
+    <!--신고 리뷰 상세정보-->
+    <div class="details">
+        <div style="padding-top: 5%;font-family: AggravoB;font-size: 40px;" >신고 리뷰</div>
+        <div class="details-layout">
+            <div style="font-family: AggravoB;font-size: 20px;">이용 화장실</div>
+            <div id="toiletName" style="font-family: AggravoB;font-size: 20px;"> 이용 화장실 이름</div>
+            <div style="font-family: AggravoM;font-size: 20px;">내용</div>
+            <div id="content" style="font-family: AggravoL;font-size: 20px;"> 리뷰 내용</div>
+            <div id="date-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">날짜</div>
+                <div id="date" style="font-family: AggravoL;font-size: 20px;">리뷰 날짜</div>
+            </div>
+            <div id="memberId-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">작성자ID</div>
+                <div id="id" style="font-family: AggravoL;font-size: 20px;">사용자 id</div>
+            </div>
+            <div id="decNum-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">신고 횟수</div>
+                <div id="decNum" style="font-family: AggravoL;font-size: 20px;">신고횟수</div>
+            </div>
+            <div class="btns">
+                <button class="penalty">벌점 부과</button>
+                <button class="dec-cancel">신고 취소</button>
+            </div>
+        </div>
+    </div>
+    <!--신고 취소-->
+    <div class="cancel-back"><!--배경-->
+        <div id="dec-cancel-modal">
+            <div style="position: relative;top:30%">해당 리뷰의 신고를 취소하시겠습니까?</div>
+            <div class="cancelbtns">
+                <form action="/review/declared/cancel" method="post">
+                    <input type="hidden" name="no" id="cancelNo">
+                    <button id="canY" type="submit">예</button>
+                </form>
+                <button id="canN">아니오</button>
+                <div class="cancelsuccess">
+                    리뷰 신고가 취소되었습니다.
+                </div>
+            </div>
+        </div>
+
+    </div>
 </div>
+<!--페이징처리-->
+<div class="pagination" style="display: flex">
+
+    <!-- 이전 버튼 -->
+    <span th:if="${startPage > 1}">
+        <a th:href="@{/review/declared(page=${startPage - 1})}">◀</a>
+    </span>
+
+    <!-- 페이지 번호 버튼 -->
+    <span th:each="i : ${#numbers.sequence(startPage, endPage)}">
+        <a th:href="@{/review/declared(page=${i})}"
+           th:text="${i}"
+           th:classappend="${i == page} ? 'active' : ''"></a>
+    </span>
+
+    <!-- 다음 버튼 -->
+    <span th:if="${endPage < totalPages}">
+        <a th:href="@{/review/declared(page=${endPage + 1})}">▶</a>
+    </span>
+
+</div>
+
+<script>
+
+    const $reviews = document.querySelectorAll('.review')
+    const $detailBtn = document.querySelectorAll('.detailbtn');
+    const $detailToiletName = document.querySelector('#toiletName')
+    const $detailContent = document.querySelector('#content')
+    const $detailDate = document.querySelector('#date')
+    const $detailId = document.querySelector('#id')
+    const $detailDecNum = document.querySelector('#decNum')
+    const $detail = document.querySelector(".details")
+    const $decCancelBtn = document.querySelector(".dec-cancel") // 신고 취소 버튼
+    const $decCancelModal = document.querySelector(".cancel-back") // 신고 취소 확인 모달
+    const $decCancelCancelBtn = document.querySelector("#canN") // 신고 취소 취소 버튼
+    const $decCancelAgreeBtn = document.querySelector("#canY") // 신고 취소 동의 벝은
+    const $decCancelSuccess = document.querySelector(".cancelsuccess") // 신고 취소 완료 버튼
+    const $decCancelReviewNo = document.querySelector("#cancelNo") // 신고할 리뷰의 번호
+
+
+    $decCancelBtn.addEventListener('click',function (){
+        $decCancelModal.style.display = 'flex'
+    })
+    $decCancelCancelBtn.addEventListener('click',function (){
+        $decCancelModal.style.display='none';
+    })
+    $decCancelAgreeBtn.addEventListener('click',function (){
+        // $decCancelModal.style.display='none'
+        $decCancelSuccess.style.display='flex'
+    })
+
+    $decCancelSuccess.addEventListener('click',function (){
+        $decCancelModal.style.display='none'
+        $decCancelSuccess.style.display='none'
+    })
+    // const $review = document.querySelectorAll(".review") // 리뷰 요약 창
+
+    let openedIndex = null;
+    // 상세버튼 눌렀을 때 모달창 띄우기
+    $detailBtn.forEach((btn,i)=>{
+        btn.addEventListener('click',function (){
+
+
+            $reviews.forEach((a)=>{
+                a.style.background='#ffffff'
+            })
+
+            const $review = btn.closest('.review');/*closest() : 가장 가까운 태그로 초기화*/
+            const content = $review.querySelector('.content')?.textContent||'';
+            const date = $review.querySelector('.date')?.textContent||'';
+            const id = $review.querySelector('.memberId')?.textContent||'';
+            const decNum = $review.querySelector('.decNum')?.textContent||'';
+            const toiletLocation = $review.querySelector('.toiletLocation')?.textContent||'';
+            const stationName = $review.querySelector('.stationName')?.textContent||'';
+            const no =  $review.querySelector('.no')?.textContent;
+            console.log(stationName+" "+toiletLocation)
+            console.log(id)
+            console.log(decNum)
+
+
+            // 버튼에 해당하는 공지사항 제목,내용 모달창에 띄우기 (비동기)
+            $detailToiletName.textContent=stationName+" "+toiletLocation
+            $detailContent.textContent=content;
+            $detailDate.textContent=date;
+            $detailId.textContent=id;
+            $detailDecNum.textContent=decNum;
+            $decCancelReviewNo.value=no;
+            console.log($decCancelReviewNo.value)
+
+            $review.style.background='#f9f9d3'
+
+            if($detail.style.display==='flex' && openedIndex === i){
+                $detail.style.display='none'
+                $review.style.background='#ffffff'
+                openedIndex = null;
+                return;
+            }
+
+            $detail.style.display='flex'
+            openedIndex = i;
+            console.log("index:"+openedIndex)
+        })
+
+        const $critreia = document.querySelector('#criteria')
+        const $inputBox = document.querySelector('#inputbox')
+
+        $critreia.addEventListener('change',function(){
+            const selectedValue = this.value;
+
+            if(selectedValue === 'member_id'){
+                $inputBox.placeholder='사용자ID를 입력해주세요'
+            } else if(selectedValue === 'station_name'){
+                $inputBox.placeholder='역명을 입력해주세요'
+            } else{
+                $inputBox.placeholder='검색기준을 입력해주세요'
+            }
+        })
+
+    })
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/review/search.html
+++ b/src/main/resources/templates/review/search.html
@@ -9,15 +9,465 @@
         }
         #revsearch{
             background: #FAFAC2;
+            display: flex;!important;
         }
         .revbtns{
             display: flex;!important;
         }
+        .review{
+            height: 9%;
+            margin-bottom: 1%;
+            background: white;
+            display: flex;
+            flex-direction: row;
+            /*border: black 1px solid;*/
+            align-items: center;
+            border-radius: 8px;
+        }
+        #pagetitle{
+            font-size: 40px;
+            position: fixed;
+            top: 15%;
+            left: 20%;
+        }
+        #search{
+            position: fixed;
+            top:15%;
+            left: 65%;
+        }
+        *{
+            cursor: pointer;
+        }
+        #content-layout{
+            display: flex;
+            flex-direction: row;
+            gap: 10px;
+        }
+        #reviewList,#details{
+            width: 500px;
+            height: 400px;
+        }
+        #reviewlist{
+            width: 30%;
+            height: 60%;
+            position: absolute;
+            left: 19%;
+            top: 22%;
+            /*border: black 10px solid; !*레이아웃 확인용*!*/
+            overflow-y: hidden;
+            scrollbar-width: none;
+            overflow-x: hidden;
+        }
+        .stationName{
+            width: 50%;
+            position: relative;
+            top: 20%;
+            font-size: 20px;
+            background-color: #FAFAC2;
+        }
+        .toiletLocation{
+            position: relative;
+            right: %;
+            top:20%;
+            font-size: 20px;
+        }
+        .detailbtn{
+            position: relative;
+            left: 95%;
+            font-size: 20px;
+        }
+        .date{
+            position: relative;
+            bottom: 20%;
+            right: 50%;
+            font-size: 10px;
+            font-family: AggravoL;
+            /*background-color: #2f1a48;*/
+            width: 12%;
+        }
+        .memberId{
+            position: relative;
+            right: 49%;
+            bottom: 20%;
+            font-size: 10px;
+            font-family: AggravoL;
+        }
+        .toiletName{
+            /*background-color: #FAFAC2;*/
+            width: 50%;
+            font-size: 20px;
+            position: relative;
+            top: 20%;
+        }
+        .details{
+            width: 30%;
+            height: 60%;
+            position: fixed;
+            left: 51%;
+            top: 22%;
+            background: white;
+            /*border: black 10px solid; !*레이아웃 확인용*!*/
+            display: none;
+            /*justify-content: center;*!*/
+            flex-direction: column;
+            align-items: center;
+            border-radius: 8px;
+        }
+        .view-details{
+            width: 30%;
+            height: 60%;
+            position: fixed;
+            left: 51%;
+            top: 22%;
+            background: white;
+            /*border: black 10px solid; !*레이아웃 확인용*!*/
+            display: flex;
+            /*justify-content: center;*!*/
+            flex-direction: column;
+            align-items: center;
+            border-radius: 8px;
+        }
+        .details-layout{
+            padding: 5%;
+            font-family: AggravoM;
+            width: 90%;
+            height: 90%;
+            /*border: black 5px solid;*/
+        }
+        #toiletName{
+            /*background-color: cyan;*/
+        }
+        #content{
+            background-color: #d9d9d9;
+            width: 100%;
+            height: 45%;
+        }
+        #date-layout{
+            /*background-color: #d9d9d9;*/
+        }
+        #memberId-layout{
+            /*background-color: #FAFAC2;*/
+            width: 50%;
+            height: 15%;
+            position: relative;
+
+
+        }
+
+        #decNum-layout{
+            /*background-color: greenyellow;*/
+            width: 50%;
+            height: 15%;
+            position: relative;
+            bottom: 15%;
+            left: 50%;
+
+        }
+
+        .penalty,.dec-cancel{
+            font-family: AggravoM;
+            font-size: 20px;
+            width: 100px;
+            height: 30px;
+            background: white;
+            border: #d9d9d9 solid 4px;
+            border-radius: 8px;
+            text-align: center;
+            align-content: center;
+        }
+        .btns{
+            position: fixed;
+            left: 68%;
+            top: 75%;
+            width: 100%;
+            height: 200%;
+            display: flex;
+            gap: 0.5%;
+        }
+        /*신고 취소 확인 모달 배경*/
+        .cancel-back{
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,50%);
+            z-index: 1100;
+            display: none;
+        }
+        /*신고 취소 확인 모달 창*/
+        #dec-cancel-modal{
+            width: 25%;
+            height: 30%;
+            background: white;
+            position: fixed;
+            top: 35%;
+            left: 37.5%;
+            z-index: 1004;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        /*신고 취소 완료 모달창*/
+        .cancelsuccess{
+            width: 25%;
+            height: 30%;
+            background: white;
+            position: fixed;
+            top: 35%;
+            left: 37.5%;
+            z-index: 1005;
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        .cancelbtns{
+            width: 30%;
+            height: 10%;
+            display: flex;
+            gap: 5%;
+            position: relative;
+            /*border: black solid 1px;*/
+            justify-content: space-between;
+            top: 70%;
+        }
+        #canN,#canY{
+            border: none;
+            width: 50px;
+            height: 30px;
+        }
+        .pagination{
+            width: 15%;
+            position: fixed;
+            top: 90%;
+            left: 45%;
+            /*border: black solid 1px;*/
+            display: flex;
+            justify-content: center;
+            gap: 10%;
+        }
+        .pagination a{
+            text-decoration: none;
+            color: black;
+            font-size: 30px;
+        }
+        .pagination a.active{
+            color: #d9d9d9;
+        }
+        @keyframes selected {
+            from{
+                transform: rotate(0deg);
+            }
+            to{
+                transform: rotate(90deg)
+            }
+        }
+        .selected{
+            /*animation: selected 0.1s linear;*/
+            transform: rotate(90deg);
+        }
+        {
+            background-color: #FAFAC2;
+            font-family: AggravoL;
+            font-size: 15px;
+            position: relative;
+            bottom: 30%;
+        }
+
     </style>
 </head>
 <body>
 <div th:include="/manager/backgroundandbanner.html"></div>
 <div th:include="/manager/sidebar-rev.html"></div>
-<div id="mainmenu">선택리뷰 메인입니다.</div>
+<div id="mainmenu">
+    <div id="pagetitle">선택 리뷰 관리</div>
+    <form action="/review/search" method="get" id="search">
+        <select name="criteria" id="criteria">
+            <option value="" th:selected="${value == '%%'}" selected>검색 기준</option>
+            <option value="station_name" id="sn" th:selected="${criteria} == 'station_name'">역명</option>
+            <option value="r.member_id" id="mi" th:selected="${criteria} == 'r.member_id'">사용자ID</option>
+        </select>
+        <input type="text" id="inputbox" name="search" placeholder="검색기준을 입력해주세요">
+        <button type="submit">검색</button>
+    </form>
+    <div id="reviewlist">
+        <div class="review" th:each="review : ${reviewList2}">
+            <div class="detailbtn">▶</div> <!--detailbtn은 여러개있을 수 있고 그에 따른 인덱스 있음-->
+            <div class="toiletName" th:text="${review.stationName} +' ' +${review.toiletLocation}"></div>
+            <div class="stationName" th:text="${review.stationName}" hidden></div><!--역명확인용-->
+            <div class="toiletLocation" th:text="${review.toiletLocation}" hidden></div><!--화장실위치확인용-->
+            <div class="date" th:text="${review.date}"></div><!--날짜 확인용-->
+            <div class="memberId" th:text="'ID : '+${review.memberId}"></div><!--리뷰작성자id 확인용-->
+            <div class="no" th:text="${review.no}" style="display: none"></div> <!--번호 확인용...-->
+            <div class="content" th:text="${review.content}" style="display: none"></div> <!--리뷰내용 확인용...-->
+            <div class="decNum" th:text="${review.decNum}" style="display: none"></div> <!--신고횟수 확인용...-->
+
+            <div class="empty"></div>
+        </div>
+    </div>
+    <!--신고 리뷰 상세정보-->
+    <div class="details">
+        <div style="padding-top: 5%;font-family: AggravoB;font-size: 40px;" >신고 리뷰</div>
+        <div class="details-layout">
+            <div style="font-family: AggravoB;font-size: 20px;">이용 화장실</div>
+            <div id="toiletName" style="font-family: AggravoB;font-size: 20px;"> 이용 화장실 이름</div>
+            <div style="font-family: AggravoM;font-size: 20px;">내용</div>
+            <div id="content" style="font-family: AggravoL;font-size: 20px;"> 리뷰 내용</div>
+            <div id="date-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">날짜</div>
+                <div id="date" style="font-family: AggravoL;font-size: 20px;">리뷰 날짜</div>
+            </div>
+            <div id="memberId-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">작성자ID</div>
+                <div id="id" style="font-family: AggravoL;font-size: 20px;">사용자 id</div>
+            </div>
+            <div id="decNum-layout">
+                <div style="font-family: AggravoM;font-size: 20px;">신고 횟수</div>
+                <div id="decNum" style="font-family: AggravoL;font-size: 20px;">신고횟수</div>
+            </div>
+            <div class="btns">
+                <button class="penalty">벌점 부과</button>
+                <button class="dec-cancel">신고 취소</button>
+            </div>
+        </div>
+    </div>
+    <!--신고 취소-->
+    <div class="cancel-back"><!--배경-->
+        <div id="dec-cancel-modal">
+            <div style="position: relative;top:30%">해당 리뷰의 신고를 취소하시겠습니까?</div>
+            <div class="cancelbtns">
+                <form action="/review/declared/cancel" method="post">
+                    <input type="hidden" name="no" id="cancelNo">
+                    <button id="canY" type="submit">예</button>
+                </form>
+                <button id="canN">아니오</button>
+                <div class="cancelsuccess">
+                    리뷰 신고가 취소되었습니다.
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+<!--페이징처리-->
+<div class="pagination" style="display: flex">
+
+    <!-- 이전 버튼 -->
+    <span th:if="${startPage2 > 1}">
+        <a th:href="@{/review/search(page2=${startPage2 - 1})}">◀</a>
+    </span>
+
+    <!-- 페이지 번호 버튼 -->
+    <span th:each="i : ${#numbers.sequence(startPage2, endPage2)}">
+        <a th:href="@{/review/search(page2=${i},criteria=${criteria},search=${search})}"
+           th:text="${i}"
+           th:classappend="${i == page2} ? 'active' : ''"></a>
+    </span>
+
+    <!-- 다음 버튼 -->
+    <span th:if="${endPage2 < totalPages2}">
+        <a th:href="@{/review/search(page2=${endPage2 + 1})}">▶</a>
+    </span>
+
+</div>
+
+<script>
+
+    const $reviews = document.querySelectorAll('.review')
+    const $detailBtn = document.querySelectorAll('.detailbtn');
+    const $detailToiletName = document.querySelector('#toiletName')
+    const $detailContent = document.querySelector('#content')
+    const $detailDate = document.querySelector('#date')
+    const $detailId = document.querySelector('#id')
+    const $detailDecNum = document.querySelector('#decNum')
+    const $detail = document.querySelector(".details")
+    const $decCancelBtn = document.querySelector(".dec-cancel") // 신고 취소 버튼
+    const $decCancelModal = document.querySelector(".cancel-back") // 신고 취소 확인 모달
+    const $decCancelCancelBtn = document.querySelector("#canN") // 신고 취소 취소 버튼
+    const $decCancelAgreeBtn = document.querySelector("#canY") // 신고 취소 동의 벝은
+    const $decCancelSuccess = document.querySelector(".cancelsuccess") // 신고 취소 완료 버튼
+    const $decCancelReviewNo = document.querySelector("#cancelNo") // 신고할 리뷰의 번호
+
+
+    $decCancelBtn.addEventListener('click',function (){
+        $decCancelModal.style.display = 'flex'
+    })
+    $decCancelCancelBtn.addEventListener('click',function (){
+        $decCancelModal.style.display='none';
+    })
+    $decCancelAgreeBtn.addEventListener('click',function (){
+        // $decCancelModal.style.display='none'
+        $decCancelSuccess.style.display='flex'
+    })
+
+    $decCancelSuccess.addEventListener('click',function (){
+        $decCancelModal.style.display='none'
+        $decCancelSuccess.style.display='none'
+    })
+    // const $review = document.querySelectorAll(".review") // 리뷰 요약 창
+
+    let openedIndex = null;
+    // 상세버튼 눌렀을 때 모달창 띄우기
+    $detailBtn.forEach((btn,i)=>{
+        btn.addEventListener('click',function (){
+
+
+            $reviews.forEach((a)=>{
+                a.style.background='#ffffff'
+            })
+
+            const $review = btn.closest('.review');/*closest() : 가장 가까운 태그로 초기화*/
+            const content = $review.querySelector('.content')?.textContent||'';
+            const date = $review.querySelector('.date')?.textContent||'';
+            const id = $review.querySelector('.memberId')?.textContent||'';
+            const decNum = $review.querySelector('.decNum')?.textContent||'';
+            const toiletLocation = $review.querySelector('.toiletLocation')?.textContent||'';
+            const stationName = $review.querySelector('.stationName')?.textContent||'';
+            const no =  $review.querySelector('.no')?.textContent;
+            console.log(stationName+" "+toiletLocation)
+            console.log(id)
+            console.log(decNum)
+
+
+            // 버튼에 해당하는 공지사항 제목,내용 모달창에 띄우기 (비동기)
+            $detailToiletName.textContent=stationName+" "+toiletLocation
+            $detailContent.textContent=content;
+            $detailDate.textContent=date;
+            $detailId.textContent=id;
+            $detailDecNum.textContent=decNum;
+            $decCancelReviewNo.value=no;
+            console.log($decCancelReviewNo.value)
+
+            $review.style.background='#f9f9d3'
+
+            if($detail.style.display==='flex' && openedIndex === i){
+                $detail.style.display='none'
+                $review.style.background='#ffffff'
+                openedIndex = null;
+                return;
+            }
+
+            $detail.style.display='flex'
+            openedIndex = i;
+            console.log("index:"+openedIndex)
+        })
+
+        const $critreia = document.querySelector('#criteria')
+        const $inputBox = document.querySelector('#inputbox')
+
+        $critreia.addEventListener('change',function(){
+            const selectedValue = this.value;
+
+            $inputBox.value='';
+
+            if(selectedValue === 'member_id'){
+                $inputBox.placeholder='사용자ID를 입력해주세요'
+            } else if(selectedValue === 'station_name'){
+                $inputBox.placeholder='역명을 입력해주세요'
+            } else{
+                $inputBox.placeholder='검색기준을 입력해주세요'
+            }
+        })
+
+    })
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/toilet/details.html
+++ b/src/main/resources/templates/toilet/details.html
@@ -221,6 +221,8 @@
                                 <br>
                                 <div>내용</div>
                                 <textarea placeholder="내용을 입력해주세요"></textarea>
+<!--                                <input type="text" name="toiletLocation" th:value="${stationName}">-->
+<!--                                <input type="text" name="stationName" th:value="${stationName} + '역 ' + ${toilet.ground} + ' ' + ${toilet.floor} + '층 ' + ${toilet.gateInOut} + ' 화장실'">-->
                             </form>
                             <button type="submit" id="regist" class="btn">작성</button>
                             <button id="cancel" class="btn">취소</button>


### PR DESCRIPTION
## ✔ 관련 이슈 번호 
#74 #75 
## 📃 작업 상세 내용 
관리자 페이지에서 신고 리뷰 관리 탭을 누르면 신고 리뷰 관리 페이지로 이동한다.
요약 리스트에는 신고를 2회 이상 받은 전체 리뷰를 보여준다.
신고 리뷰가 악의적으로 신고 되었을 경우 신고 취소를 할 수 있다.

관리자 페이지에서 선택 리뷰 관리 탭을 누르면 신고 리뷰 관리 페이지로 이동한다.
요약 리스트에는 전체 리뷰를 보여준다.
역 명 또는 사용자ID 를 기준으로 검색하여 리뷰를 조회할 수 있다.
## 📸 결과 
신고 취소
<img width="1920" height="916" alt="image" src="https://github.com/user-attachments/assets/2ec19e98-fcdf-4889-a836-f6d9d408a009" />
기준 선택
<img width="1920" height="908" alt="image" src="https://github.com/user-attachments/assets/7fc02b5f-eadb-49f2-bdcc-24633c2642be" />
역 명 검색
<img width="1920" height="918" alt="image" src="https://github.com/user-attachments/assets/774e3149-1570-4d4a-85b3-399a9661004a" />
