### PR TITLE
[fix] 관리자 문의 관리 페이지 답변 거절, 답변 등록 버튼 비활성화

### DIFF
--- a/src/main/resources/templates/request/manager.html
+++ b/src/main/resources/templates/request/manager.html
@@ -353,6 +353,7 @@
 
 
 
+
     </style>
 </head>
 <body>
@@ -406,7 +407,7 @@
                 <div id="did" style="font-family: AggravoL;font-size: 20px;" hidden></div>
             </div>
             <div id="dno" style="display: none"></div>
-            <div class="btns">
+            <div class="btns detbtns">
                 <button class="deletebtn">거절</button>
                 <button class="updatebtn">답변</button>
             </div>
@@ -528,6 +529,8 @@
     const $contentinput1 = document.querySelector('#ucontent');
     const $updateNoInput = document.querySelector('#updateNo')
 
+    const $detbtns = document.querySelector('.detbtns')
+
     $contentinput1.addEventListener('input',function (){
 
         let currenlength1 = $contentinput1.value.length;
@@ -640,8 +643,17 @@
             const no = $notice.querySelector('.no')?.textContent||'';
             const answer = $notice.querySelector('.answer')?.textContent||'';
             const reject = $notice.querySelector('.reject')?.textContent||'';
+            const status = $notice.querySelector('.status')?.textContent||'';
+
+            if(status!=='대기중'){
+                $detbtns.style.display='none';
+            }
+            if(status==='대기중'){
+                $detbtns.style.display='flex';
+            }
 
             $notice.style.background="#fafad2"
+
 
 
             // 버튼에 해당하는 공지사항 제목,내용 모달창에 띄우기 (비동기)
@@ -658,6 +670,7 @@
             }
             if(reject==="" && answer===""){
                 $danswer.textContent="";
+
             }
 
             // 인덱스에 해당하는 내용을 가진 모달창이 열려있을 때 상세버튼을 누르면 꺼지게


### PR DESCRIPTION

## ✔ 관련 이슈 번호 
#119 
## 📃 작업 상세 내용 
문의 중 답변이 거절되었거나 이미 등록된 문의에 한하여 거절,답변 버튼을 비활성화한다.

## 📸 결과 
개발 전
<img width="1913" height="906" alt="image" src="https://github.com/user-attachments/assets/3b1611b0-c286-4cfe-bc0b-ec6e93a10246" />
개발 후
<img width="1916" height="909" alt="image" src="https://github.com/user-attachments/assets/46b62af6-bc41-4a16-8821-d0722126dd75" />
소스 코드
<img width="292" height="151" alt="image" src="https://github.com/user-attachments/assets/a0b7be7d-cea9-4f5e-a58a-194b58ae671c" />

